### PR TITLE
docs: expand quick start configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Please note that the app is intended mostly for educational purposes and should 
 You can start using this Sample App now:
 1. Clone this repo to your localhost
 2. Edit `env.ts` to point to your environment
+   - Set the `TENANT` constant to your Dynatrace tenant ID.
+   - For Dynatrace **SaaS** use the `.apps.dynatrace.com` domain. A typical configuration looks like:
+
+     ```ts
+     const TENANT = '<tenant>'; 
+     export const ENVIRONMENT_URL = `https://${TENANT}.apps.dynatrace.com/`;
+     ```
+
+   - For Dynatrace **Labs** keep the `.dev.dynatracelabs.com` domains as provided in `env.ts`.
+   
+   Using the wrong URL will result in **404** responses during authentication.
 3. Test locally: `npm run start`
 4. Deploy using `npm run deploy`
 


### PR DESCRIPTION
## Summary
- document how to adjust `TENANT` and domains in `env.ts`
- warn about 404 errors when the domain does not match
- give a SaaS example URL

## Testing
- `npm run lint`
- `npm run test:api` *(fails: Can't find a root directory while resolving a config file path)*

------
https://chatgpt.com/codex/tasks/task_e_684bcac945588322a03e26a5a94be36d