### PR TITLE
Fix imports and forms for latest Strato

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,22 @@ Please note that the app is intended mostly for educational purposes and should 
 ## TL;DR
 You can start using this Sample App now:
 1. Clone this repo to your localhost
-2. Edit `env.ts` to point to your environment
+2. Install dependencies using `npm install`
+3. Edit `env.ts` to point to your environment
    - Set the `TENANT` constant to your Dynatrace tenant ID.
    - For Dynatrace **SaaS** use the `.apps.dynatrace.com` domain. A typical configuration looks like:
 
      ```ts
-     const TENANT = '<tenant>'; 
-     export const ENVIRONMENT_URL = `https://${TENANT}.apps.dynatrace.com/`;
+    const TENANT = '<tenant>';
+    export const ENVIRONMENT_URL = `https://${TENANT}.live.dynatrace.com/`;
+    export const LATEST_DYNATRACE_ENVIRONMENT_URL = `https://${TENANT}.apps.dynatrace.com/`;
      ```
 
    - For Dynatrace **Labs** keep the `.dev.dynatracelabs.com` domains as provided in `env.ts`.
    
    Using the wrong URL will result in **404** responses during authentication.
-3. Test locally: `npm run start`
-4. Deploy using `npm run deploy`
+4. Test locally: `npm run start`
+5. Deploy using `npm run deploy`
 
 Or, keep reading to understand how to modify this app for your own purposes or build your own.
 

--- a/env.ts
+++ b/env.ts
@@ -1,9 +1,9 @@
 // ------------------------------------------
 // CHANGE THIS TO POINT TO YOUR ENVIRONMENT:
-const TENANT = 'umsaywsjuo';
+const TENANT = '<tenant>';
 
-// the url of the your current dynatrace environment
-export const ENVIRONMENT_URL = `https://${TENANT}.dev.dynatracelabs.com/`;
-// the url of the your latest dynatrace environment
-export const LATEST_DYNATRACE_ENVIRONMENT_URL = `https://${TENANT}.dev.apps.dynatracelabs.com/`;
+// the url of your current Dynatrace environment
+export const ENVIRONMENT_URL = `https://${TENANT}.live.dynatrace.com/`;
+// the url of your latest Dynatrace environment
+export const LATEST_DYNATRACE_ENVIRONMENT_URL = `https://${TENANT}.apps.dynatrace.com/`;
 // ------------------------------------------

--- a/src/app/components/CloudTable.tsx
+++ b/src/app/components/CloudTable.tsx
@@ -1,11 +1,7 @@
 import React, { useState, useMemo } from 'react';
-import {
-  DataTable,
-  Flex,
-  Button,
-  TableColumn,
-  Menu,
-} from '@dynatrace/strato-components-preview';
+import { DataTable, TableColumn, Menu } from '@dynatrace/strato-components-preview';
+import { Flex } from '@dynatrace/strato-components/layouts';
+import { Button } from '@dynatrace/strato-components/buttons';
 import { SyncIcon, DotMenuIcon } from '@dynatrace/strato-icons';
 import Spacings from '@dynatrace/strato-design-tokens/spacings';
 

--- a/src/app/components/HostsTable.tsx
+++ b/src/app/components/HostsTable.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { DataTable, Menu, Button, IntentButton } from '@dynatrace/strato-components-preview';
+import { DataTable, Menu } from '@dynatrace/strato-components-preview';
+import { Button, IntentButton } from '@dynatrace/strato-components/buttons';
 import { DotMenuIcon } from '@dynatrace/strato-icons';
 import { CloudType } from '../types/CloudTypes';
 import { OneAgentIcon } from '../icons/OneAgent';

--- a/src/app/components/WhatsNext.tsx
+++ b/src/app/components/WhatsNext.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Container, ExternalLink, Heading, Paragraph } from '@dynatrace/strato-components-preview';
+import { Container } from '@dynatrace/strato-components/layouts';
+import { ExternalLink, Heading, Paragraph } from '@dynatrace/strato-components/typography';
 import { Flex } from '@dynatrace/strato-components/layouts';
 
 export const WhatsNext = () => {
@@ -16,13 +17,13 @@ export const WhatsNext = () => {
       paddingX={16}
       alignSelf='center'
     >
-      <Flex flexDirection='column' alignItems='left' gap={4}>
+      <Flex flexDirection='column' alignItems='flex-start' gap={4}>
         <Heading as='h2' level={6}>
           What&apos;s next?
         </Heading>
         <Paragraph>Fork this app on GitHub and learn how to write apps for Dynatrace.</Paragraph>
       </Flex>
-      <Flex alignItems='right'>
+      <Flex alignItems='flex-end'>
         <ExternalLink href='https://github.com/Dynatrace/monitoring-coverage'>Fork on Github</ExternalLink>
       </Flex>
     </Container>

--- a/src/app/components/cells/ActionsCell.tsx
+++ b/src/app/components/cells/ActionsCell.tsx
@@ -3,7 +3,7 @@ import { CloudType } from 'src/app/types/CloudTypes';
 import { coverageRatio } from './coverage-ratio';
 import { useHostsStatus } from 'src/app/hooks/useHostsStatus';
 import { useOneAgentHosts } from 'src/app/hooks/useOneAgentHosts';
-import { ErrorIcon, SyncIcon } from '@dynatrace/strato-icons';
+import { WarningIcon, SyncIcon } from '@dynatrace/strato-icons';
 import { Button } from '@dynatrace/strato-components/buttons';
 import { OneAgentIcon } from 'src/app/icons/OneAgent';
 
@@ -26,7 +26,7 @@ export const ActionsCell = ({ type, onClick }: ActionsCellProps) => {
 
   if (isLoading) return null;
 
-  if (isError) return <ErrorIcon />;
+  if (isError) return <WarningIcon />;
 
   const coverage = coverageRatio(status.data, oneagent.data[type]);
 

--- a/src/app/components/cells/HostsCell.tsx
+++ b/src/app/components/cells/HostsCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CloudType } from '../../types/CloudTypes';
 import { useHostsStatus } from '../../hooks/useHostsStatus';
-import { ErrorIcon } from '@dynatrace/strato-icons';
+import { WarningIcon } from '@dynatrace/strato-icons';
 import { format } from '@dynatrace-sdk/units';
 
 type HostsCellProps = {
@@ -13,7 +13,7 @@ export const HostsCell = ({ type }: HostsCellProps) => {
 
   if (isLoading) return <span>Loading...</span>;
 
-  if (isError) return <ErrorIcon />;
+  if (isError) return <WarningIcon />;
 
   return <>{data.hosts !== undefined ? format(data.hosts) : '-'}</>;
 };

--- a/src/app/components/cells/OneAgentCoverageCell.tsx
+++ b/src/app/components/cells/OneAgentCoverageCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CloudType } from '../../types/CloudTypes';
 import { useHostsStatus } from '../../hooks/useHostsStatus';
-import { ErrorIcon } from '@dynatrace/strato-icons';
+import { WarningIcon } from '@dynatrace/strato-icons';
 import { format, units } from '@dynatrace-sdk/units';
 import { Indicator } from '../Indicator';
 import { useOneAgentHosts } from 'src/app/hooks/useOneAgentHosts';
@@ -20,7 +20,7 @@ export const OneAgentCoverageCell = ({ type }: OneAgentCoverageCellProps) => {
 
   if (isLoading) return null;
 
-  if (isError) return <ErrorIcon />;
+  if (isError) return <WarningIcon />;
 
   const coverage = coverageRatio(status.data, oneagent.data[type]);
   if (coverage > 100) return <Indicator state='critical'>&gt; 100 %</Indicator>;

--- a/src/app/components/cells/OneAgentHostsCell.tsx
+++ b/src/app/components/cells/OneAgentHostsCell.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CloudType } from '../../types/CloudTypes';
-import { ErrorIcon } from '@dynatrace/strato-icons';
+import { WarningIcon } from '@dynatrace/strato-icons';
 import { format } from '@dynatrace-sdk/units';
 import { useOneAgentHosts } from 'src/app/hooks/useOneAgentHosts';
 
@@ -13,7 +13,7 @@ export const OneAgentHostsCell = ({ type }: OneAgentHostsCellProps) => {
 
   if (isLoading) return null;
 
-  if (isError) return <ErrorIcon />;
+  if (isError) return <WarningIcon />;
 
   return <>{data[type] !== undefined ? format(data[type] || 0) : '-'}</>;
 };

--- a/src/app/components/cells/PriorityCell.tsx
+++ b/src/app/components/cells/PriorityCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CloudType } from '../../types/CloudTypes';
 import { useHostsStatus } from '../../hooks/useHostsStatus';
-import { ErrorIcon } from '@dynatrace/strato-icons';
+import { WarningIcon } from '@dynatrace/strato-icons';
 import { Indicator } from '../Indicator';
 import { useOneAgentHosts } from 'src/app/hooks/useOneAgentHosts';
 import { coverageRatio } from './coverage-ratio';
@@ -19,7 +19,7 @@ export const PriorityCell = ({ type }: PriorityCellProps) => {
 
   if (isLoading) return null;
 
-  if (isError) return <ErrorIcon />;
+  if (isError) return <WarningIcon />;
 
   const oneagentHosts = oneagent.data[type];
 

--- a/src/app/components/cells/StatusCell.tsx
+++ b/src/app/components/cells/StatusCell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CloudType } from '../../types/CloudTypes';
 import { useHostsStatus } from '../../hooks/useHostsStatus';
 
-import { ErrorIcon, SyncDoneIcon, SyncOffIcon } from '@dynatrace/strato-icons';
+import { WarningIcon, SyncDoneIcon, SyncOffIcon } from '@dynatrace/strato-icons';
 import { Indicator } from '../Indicator';
 import { useOneAgentHosts } from 'src/app/hooks/useOneAgentHosts';
 
@@ -16,7 +16,7 @@ export const StatusCell = ({ type }: StatusCellProps) => {
 
   if (isLoading) return <span>Loading...</span>;
 
-  if (isError) return <ErrorIcon />;
+  if (isError) return <WarningIcon />;
 
   if (data.status) {
     return (

--- a/src/app/components/demo/AppIntro.tsx
+++ b/src/app/components/demo/AppIntro.tsx
@@ -1,4 +1,4 @@
-import { Heading, List, Paragraph } from '@dynatrace/strato-components-preview';
+import { Heading, List, Paragraph } from '@dynatrace/strato-components/typography';
 import { Flex } from '@dynatrace/strato-components/layouts';
 import { Text } from '@dynatrace/strato-components/typography';
 import React from 'react';

--- a/src/app/components/demo/DetailView.tsx
+++ b/src/app/components/demo/DetailView.tsx
@@ -1,4 +1,4 @@
-import { Heading } from '@dynatrace/strato-components-preview';
+import { Heading } from '@dynatrace/strato-components/typography';
 import { Flex } from '@dynatrace/strato-components/layouts';
 import { Text } from '@dynatrace/strato-components/typography';
 import { CodeIcon, ChatIcon } from '@dynatrace/strato-icons';

--- a/src/app/components/demo/DetailsCard.tsx
+++ b/src/app/components/demo/DetailsCard.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Container, Surface } from '@dynatrace/strato-components-preview';
-import { Flex } from '@dynatrace/strato-components/layouts';
+import { Container, Surface, Flex } from '@dynatrace/strato-components/layouts';
 import { Text } from '@dynatrace/strato-components/typography';
 import { ExternalLinkIcon } from '@dynatrace/strato-icons';
 

--- a/src/app/components/modals/ConnectAWSModal.tsx
+++ b/src/app/components/modals/ConnectAWSModal.tsx
@@ -1,15 +1,15 @@
 import React, { FormEvent, useRef, useState } from 'react';
+import { Modal } from '@dynatrace/strato-components-preview/overlays';
 import {
-  Modal,
   FormField,
   TextInput,
-  Select,
-  SelectOption,
-  SelectedKeys,
+  SelectV2,
+  SelectV2Option,
   PasswordInput,
   Button,
   FieldSet,
-} from '@dynatrace/strato-components-preview';
+  Label,
+} from '@dynatrace/strato-components-preview/forms';
 import { Flex } from '@dynatrace/strato-components/layouts';
 import { Text } from '@dynatrace/strato-components/typography';
 import { Cloud } from '../../types/CloudTypes';
@@ -23,7 +23,7 @@ type ConnectAWSModalProps = {
 
 export const ConnectAWSModal = ({ modalOpen, onDismiss, selectedCloud }: ConnectAWSModalProps) => {
   const formRef = useRef<HTMLFormElement>(null);
-  const [auth, setAuth] = useState<SelectedKeys | null>(['ROLE']);
+  const [auth, setAuth] = useState<React.Key[] | null>(['ROLE']);
 
   const { mutate } = useAWSCredentials();
 
@@ -50,38 +50,42 @@ export const ConnectAWSModal = ({ modalOpen, onDismiss, selectedCloud }: Connect
               &nbsp; Add {selectedCloud?.cloud} integration:
             </Text>
           </Flex>
-          <FormField label='Connection name' required>
+          <FormField>
+            <Label required>Connection name</Label>
             <TextInput placeholder='For example, Dynatrace integration' name='name' />
           </FormField>
           <FieldSet name='authenticationData'>
-            <FormField label='Authentication method' required>
-              <Select name='auth' onChange={setAuth} selectedId={auth}>
-                <SelectOption id='KEYS' value='KEYS'>
+            <FormField>
+              <Label required>Authentication method</Label>
+              <SelectV2 name='auth' onChange={setAuth} selectedId={auth}>
+                <SelectV2Option id='KEYS' value='KEYS'>
                   Key-based authentication
-                </SelectOption>
-                <SelectOption id='ROLE' value='ROLE'>
+                </SelectV2Option>
+                <SelectV2Option id='ROLE' value='ROLE'>
                   Role-based authentication
-                </SelectOption>
-              </Select>
+                </SelectV2Option>
+              </SelectV2>
             </FormField>
           </FieldSet>
           {auth?.includes('KEYS') ? (
             <Flex flexDirection='column' gap={16}>
-              <Select defaultSelectedId={['AWS_DEFAULT']} name='partition'>
-                <SelectOption id='AWS_DEFAULT' value='AWS_DEFAULT'>
+              <SelectV2 defaultSelectedId={['AWS_DEFAULT']} name='partition'>
+                <SelectV2Option id='AWS_DEFAULT' value='AWS_DEFAULT'>
                   Default
-                </SelectOption>
-                <SelectOption id='AWS_US_GOV' value='AWS_US_GOV'>
+                </SelectV2Option>
+                <SelectV2Option id='AWS_US_GOV' value='AWS_US_GOV'>
                   US Gov
-                </SelectOption>
-                <SelectOption id='AWS_CN' value='AWS_CN'>
+                </SelectV2Option>
+                <SelectV2Option id='AWS_CN' value='AWS_CN'>
                   China
-                </SelectOption>
-              </Select>
-              <FormField label='Access Key ID' required>
+                </SelectV2Option>
+              </SelectV2>
+              <FormField>
+                <Label required>Access Key ID</Label>
                 <TextInput placeholder='Access key' name='accessKeyId' required />
               </FormField>
-              <FormField label='Secret access key' required>
+              <FormField>
+                <Label required>Secret access key</Label>
                 <PasswordInput placeholder='Secret key' name='secretKeyId' required />
               </FormField>
             </Flex>
@@ -90,13 +94,16 @@ export const ConnectAWSModal = ({ modalOpen, onDismiss, selectedCloud }: Connect
           )}
           {auth?.includes('ROLE') && (
             <Flex flexDirection='column' gap={16}>
-              <FormField label='IAM role that Dynatrace should use to get monitoring data'>
+              <FormField>
+                <Label>IAM role that Dynatrace should use to get monitoring data</Label>
                 <TextInput placeholder='Role for this connection' name='role' />
               </FormField>
-              <FormField label='Your Amazon account ID'>
+              <FormField>
+                <Label>Your Amazon account ID</Label>
                 <TextInput placeholder='Account ID' name='accountId' />
               </FormField>
-              <FormField label='Token (use this value as the External ID for your IAM role)'>
+              <FormField>
+                <Label>Token (use this value as the External ID for your IAM role)</Label>
                 <PasswordInput placeholder='********************' name='externalId' />
               </FormField>
             </Flex>

--- a/src/app/components/modals/ConnectAzureModal.tsx
+++ b/src/app/components/modals/ConnectAzureModal.tsx
@@ -1,5 +1,6 @@
 import React, { FormEvent, useRef } from 'react';
-import { Modal, FormField, TextInput, PasswordInput, Button } from '@dynatrace/strato-components-preview';
+import { Modal } from '@dynatrace/strato-components-preview/overlays';
+import { FormField, TextInput, PasswordInput, Button, Label } from '@dynatrace/strato-components-preview/forms';
 import { Flex } from '@dynatrace/strato-components/layouts';
 import { Text } from '@dynatrace/strato-components/typography';
 import { Cloud } from '../../types/CloudTypes';
@@ -35,16 +36,20 @@ export const ConnectAzureModal = ({ modalOpen, onDismiss, selectedCloud }: Conne
               &nbsp; Add {selectedCloud.cloud} integration:
             </Text>
           </Flex>
-          <FormField label='Connection name' required>
+          <FormField>
+            <Label required>Connection name</Label>
             <TextInput placeholder='For example, Dynatrace integration' name='name' />
           </FormField>
-          <FormField label='Client ID' required>
+          <FormField>
+            <Label required>Client ID</Label>
             <TextInput placeholder='For example, 98989ae2-4566-4efd-9db8-e194bb3910e4' name='clientId' />
           </FormField>
-          <FormField label='Tenant ID' required>
+          <FormField>
+            <Label required>Tenant ID</Label>
             <TextInput placeholder='For example, 68345fd1-3216-4aed-7be2-a244bb3907b2' name='tenantId' />
           </FormField>
-          <FormField label='Secret Key' required>
+          <FormField>
+            <Label required>Secret Key</Label>
             <PasswordInput placeholder='**********************' name='secretKey' />
           </FormField>
 

--- a/src/app/components/modals/ConnectCloudModal.tsx
+++ b/src/app/components/modals/ConnectCloudModal.tsx
@@ -1,5 +1,6 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { Modal, FormField, TextInput, Button } from '@dynatrace/strato-components-preview';
+import { Modal } from '@dynatrace/strato-components-preview/overlays';
+import { FormField, TextInput, Button, Label } from '@dynatrace/strato-components-preview/forms';
 import { Flex } from '@dynatrace/strato-components/layouts';
 import { Text } from '@dynatrace/strato-components/typography';
 import { ExternalLinkIcon } from '@dynatrace/strato-icons';
@@ -33,11 +34,14 @@ export const ConnectCloudModal = ({ modalOpen, onDismiss, selectedCloud }: Conne
         </Flex>
         {demoMode && (
           <Flex flexDirection='column' gap={16}>
-            <FormField label='(Mock)'>
-              <FormField label='API URL'>
+            <FormField>
+              <Label>(Mock)</Label>
+              <FormField>
+                <Label>API URL</Label>
                 <TextInput placeholder='https://xxx.xxxxxxxx.xxx/xxx' />
               </FormField>
-              <FormField label='API Key'>
+              <FormField>
+                <Label>API Key</Label>
                 <TextInput placeholder='xxxxxxxxxxxxxxxxxxxxxxxxxxxx' />
               </FormField>
             </FormField>

--- a/src/app/components/modals/ConnectVMWareModal.tsx
+++ b/src/app/components/modals/ConnectVMWareModal.tsx
@@ -1,11 +1,6 @@
 import React, { FormEvent, useRef, } from 'react';
-import {
-  Modal,
-  FormField,
-  TextInput,
-  PasswordInput,
-  Button,
-} from '@dynatrace/strato-components-preview';
+import { Modal } from '@dynatrace/strato-components-preview/overlays';
+import { FormField, TextInput, PasswordInput, Button, Label } from '@dynatrace/strato-components-preview/forms';
 import { Flex } from '@dynatrace/strato-components/layouts';
 import { Text } from '@dynatrace/strato-components/typography';
 import { Cloud } from '../../types/CloudTypes';
@@ -45,16 +40,20 @@ export const ConnectVMWareModal = ({ modalOpen, onDismiss, selectedCloud }: Conn
               &nbsp; Add {selectedCloud?.cloud} integration:
             </Text>
           </Flex>
-          <FormField label='Name this connection' required>
+          <FormField>
+            <Label required>Name this connection</Label>
             <TextInput placeholder='For example, Dynatrace integration' name='label' />
           </FormField>
-          <FormField label='Specify the IP address or name of the vCenter or standalone ESXi host:'>
+          <FormField>
+            <Label>Specify the IP address or name of the vCenter or standalone ESXi host:</Label>
             <TextInput placeholder='For example, Vcenter01' name='ipaddress' />
           </FormField>
-          <FormField label='Provide user credentials for the vCenter or standalone ESXi host:'>
+          <FormField>
+            <Label>Provide user credentials for the vCenter or standalone ESXi host:</Label>
             <TextInput placeholder='Account ID' name='username' />
           </FormField>
-          <FormField label='Password'>
+          <FormField>
+            <Label>Password</Label>
             <PasswordInput placeholder='********************' name='password' />
           </FormField>
           <Flex flexGrow={0} justifyContent='flex-end'>

--- a/src/app/components/modals/InstallOneAgentModal.tsx
+++ b/src/app/components/modals/InstallOneAgentModal.tsx
@@ -1,16 +1,16 @@
 import React, { useState } from 'react';
+import { Modal } from '@dynatrace/strato-components-preview/overlays';
+import { Flex } from '@dynatrace/strato-components/layouts';
 import {
-  Modal,
-  Flex,
   FormField,
-  Select,
-  SelectOption,
-  SelectedKeys,
+  SelectV2,
+  SelectV2Option,
   TextInput,
   TextArea,
   Hint,
-  ProgressBar,
-} from '@dynatrace/strato-components-preview';
+  Label,
+} from '@dynatrace/strato-components-preview/forms';
+import { ProgressBar } from '@dynatrace/strato-components/content';
 import { Text } from '@dynatrace/strato-components/typography';
 import { Button } from '@dynatrace/strato-components/buttons';
 import {
@@ -46,12 +46,12 @@ export const InstallOneAgentModal = ({ modalOpen, onDismiss, ips, cloudType }: I
   //visual states
   const [optionsOpen, setOptionsOpen] = useState(false);
   //form states
-  const [mode, setMode] = useState<SelectedKeys>(['infrastructure']);
-  const [installerType, setInstallerType] = useState<SelectedKeys>(['default']);
+  const [mode, setMode] = useState<React.Key[]>(['infrastructure']);
+  const [installerType, setInstallerType] = useState<React.Key[]>(['default']);
   const [disabledInstallerTypes, setDisabledInstallerTypes] = useState<string[]>([]);
-  const [arch, setArch] = useState<SelectedKeys>(['all']);
+  const [arch, setArch] = useState<React.Key[]>(['all']);
   const [disabledArchs, setDisabledArchs] = useState<string[]>([]);
-  const [osType, setOsType] = useState<{ keys: SelectedKeys; value: string }>({ keys: ['unix'], value: 'Linux' });
+  const [osType, setOsType] = useState<{ keys: React.Key[]; value: string }>({ keys: ['unix'], value: 'Linux' });
   const [networkZone, setNetworkZone] = useState<string | undefined>('');
 
   const { data: token } = useInstallerDownloadToken();
@@ -78,7 +78,7 @@ export const InstallOneAgentModal = ({ modalOpen, onDismiss, ips, cloudType }: I
 
   const { mutate: downloadOneAgent, isLoading: downloading } = useDownloadOneAgent();
 
-  const selectOsType = (keys: SelectedKeys, value: string) => {
+  const selectOsType = (keys: React.Key[], value: string) => {
     const archs = Object.values(GetAgentInstallerMetaInfoQueryArch);
     setOsType({ keys, value });
     switch (keys[0]) {
@@ -133,7 +133,8 @@ export const InstallOneAgentModal = ({ modalOpen, onDismiss, ips, cloudType }: I
 
         {/* Step 1 - Copy IP list */}
         <Flex flexDirection='row'>
-          <FormField label='IP list'>
+          <FormField>
+            <Label>IP list</Label>
             <TextArea readOnly rows={3} cols={TEXTCOLS} key={ips} defaultValue={ips} />
             <CopyButton contentToCopy={ips} />
           </FormField>
@@ -141,25 +142,27 @@ export const InstallOneAgentModal = ({ modalOpen, onDismiss, ips, cloudType }: I
 
         {/* Step 2 - Pick OneAgent mode */}
         <Flex flexDirection='row'>
-          <FormField label='OS Type'>
-            <Select selectedId={osType.keys} onChange={selectOsType}>
-              <SelectOption id='unix'>Linux</SelectOption>
-              <SelectOption id='windows'>Windows</SelectOption>
-              <SelectOption id='aix'>AIX</SelectOption>
-              <SelectOption id='solaris'>Solaris</SelectOption>
-              <SelectOption id='zos'>zOS</SelectOption>
-            </Select>
+          <FormField>
+            <Label>OS Type</Label>
+            <SelectV2 selectedId={osType.keys} onChange={selectOsType}>
+              <SelectV2Option id='unix'>Linux</SelectV2Option>
+              <SelectV2Option id='windows'>Windows</SelectV2Option>
+              <SelectV2Option id='aix'>AIX</SelectV2Option>
+              <SelectV2Option id='solaris'>Solaris</SelectV2Option>
+              <SelectV2Option id='zos'>zOS</SelectV2Option>
+            </SelectV2>
           </FormField>
-          <FormField label='OneAgent Mode'>
-            <Select
+          <FormField>
+            <Label>OneAgent Mode</Label>
+            <SelectV2
               selectedId={mode}
               onChange={(value) => value !== null && setMode(value)}
               disabledKeys={['discovery']}
             >
-              <SelectOption id='discovery'>Discovery</SelectOption>
-              <SelectOption id='infrastructure'>Infrastructure</SelectOption>
-              <SelectOption id='fullstack'>FullStack</SelectOption>
-            </Select>
+              <SelectV2Option id='discovery'>Discovery</SelectV2Option>
+              <SelectV2Option id='infrastructure'>Infrastructure</SelectV2Option>
+              <SelectV2Option id='fullstack'>FullStack</SelectV2Option>
+            </SelectV2>
           </FormField>
         </Flex>
 
@@ -171,34 +174,37 @@ export const InstallOneAgentModal = ({ modalOpen, onDismiss, ips, cloudType }: I
             Optional Parameters
           </Button>
           <Flex flexDirection='column' marginTop={8}>
-            <FormField label='Installer type'>
-              <Select
+            <FormField>
+              <Label>Installer type</Label>
+              <SelectV2
                 name='mode'
                 selectedId={installerType}
                 onChange={(value) => value !== null && setInstallerType(value)}
                 disabledKeys={disabledInstallerTypes}
               >
-                <SelectOption id='default'>Default</SelectOption>
-                <SelectOption id='paas'>PaaS</SelectOption>
-                <SelectOption id='paas-sh'>PaaS sh</SelectOption>
-              </Select>
+                <SelectV2Option id='default'>Default</SelectV2Option>
+                <SelectV2Option id='paas'>PaaS</SelectV2Option>
+                <SelectV2Option id='paas-sh'>PaaS sh</SelectV2Option>
+              </SelectV2>
             </FormField>
-            <FormField label='Architecture'>
-              <Select
+            <FormField>
+              <Label>Architecture</Label>
+              <SelectV2
                 selectedId={arch}
                 onChange={(value) => value !== null && setArch(value)}
                 disabledKeys={disabledArchs}
               >
-                <SelectOption id='all'>Default</SelectOption>
-                <SelectOption id='x86'>x86</SelectOption>
-                <SelectOption id='ppc'>ppc</SelectOption>
-                <SelectOption id='ppcle'>ppcle</SelectOption>
-                <SelectOption id='sparc'>sparc</SelectOption>
-                <SelectOption id='arm'>arm</SelectOption>
-                <SelectOption id='s390'>s390</SelectOption>
-              </Select>
+                <SelectV2Option id='all'>Default</SelectV2Option>
+                <SelectV2Option id='x86'>x86</SelectV2Option>
+                <SelectV2Option id='ppc'>ppc</SelectV2Option>
+                <SelectV2Option id='ppcle'>ppcle</SelectV2Option>
+                <SelectV2Option id='sparc'>sparc</SelectV2Option>
+                <SelectV2Option id='arm'>arm</SelectV2Option>
+                <SelectV2Option id='s390'>s390</SelectV2Option>
+              </SelectV2>
             </FormField>
-            <FormField label='Network Zone'>
+            <FormField>
+              <Label>Network Zone</Label>
               <TextInput value={networkZone} onChange={setNetworkZone} />
             </FormField>
           </Flex>
@@ -212,7 +218,8 @@ export const InstallOneAgentModal = ({ modalOpen, onDismiss, ips, cloudType }: I
             </ProgressBar>
           ) : (
             <>
-              <FormField label='Get OneAgent'>
+              <FormField>
+                <Label>Get OneAgent</Label>
                 <TextArea
                   readOnly
                   rows={2}
@@ -235,7 +242,8 @@ export const InstallOneAgentModal = ({ modalOpen, onDismiss, ips, cloudType }: I
                   {downloading ? <span>Loading...</span> : null}
                 </Flex>
               </FormField>
-              <FormField label='Install 1-liner'>
+              <FormField>
+                <Label>Install 1-liner</Label>
                 <TextArea
                   readOnly
                   rows={2}


### PR DESCRIPTION
## Summary
- update environment placeholders
- clarify README environment setup and dependency install
- update Strato component imports for v1.6
- replace deprecated FormField `label` prop with `<Label>`
- swap `ErrorIcon` with `WarningIcon`

## Testing
- `npm install` *(fails: could not resolve dependencies)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test:api` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc490eed08322ae2ccbbb5469045e